### PR TITLE
PMM-10948: extend server metrics to allow adding custom labels for server grpc

### DIFF
--- a/examples/grpc-server-with-prometheus/server/server.go
+++ b/examples/grpc-server-with-prometheus/server/server.go
@@ -72,8 +72,7 @@ func main() {
 	// Register your service.
 	pb.RegisterDemoServiceServer(grpcServer, demoServer)
 
-	// Initialize all metrics.
-	grpcMetrics.InitializeMetrics(grpcServer)
+	grpc_prometheus.PrometheusMustRegister(grpcMetrics)
 
 	// Start your http server for prometheus.
 	go func() {

--- a/examples/grpc-server-with-prometheus/server/server.go
+++ b/examples/grpc-server-with-prometheus/server/server.go
@@ -62,8 +62,8 @@ func main() {
 
 	// Create a gRPC Server with gRPC interceptor.
 	grpcServer := grpc.NewServer(
-		grpc.StreamInterceptor(grpcMetrics.StreamServerInterceptor),
-		grpc.UnaryInterceptor(grpcMetrics.UnaryServerInterceptor),
+		grpc.StreamInterceptor(grpcMetrics.StreamServerInterceptor()),
+		grpc.UnaryInterceptor(grpcMetrics.UnaryServerInterceptor()),
 	)
 
 	// Create a new api server.

--- a/examples/grpc-server-with-prometheus/server/server.go
+++ b/examples/grpc-server-with-prometheus/server/server.go
@@ -62,8 +62,8 @@ func main() {
 
 	// Create a gRPC Server with gRPC interceptor.
 	grpcServer := grpc.NewServer(
-		grpc.StreamInterceptor(grpcMetrics.StreamServerInterceptor()),
-		grpc.UnaryInterceptor(grpcMetrics.UnaryServerInterceptor()),
+		grpc.StreamInterceptor(grpcMetrics.StreamServerInterceptor),
+		grpc.UnaryInterceptor(grpcMetrics.UnaryServerInterceptor),
 	)
 
 	// Create a new api server.

--- a/examples/grpc-server-with-prometheus/server/server.go
+++ b/examples/grpc-server-with-prometheus/server/server.go
@@ -72,7 +72,7 @@ func main() {
 	// Register your service.
 	pb.RegisterDemoServiceServer(grpcServer, demoServer)
 
-	grpc_prometheus.PrometheusMustRegister(grpcMetrics)
+	grpcMetrics.MustRegister()
 
 	// Start your http server for prometheus.
 	go func() {

--- a/server.go
+++ b/server.go
@@ -6,41 +6,10 @@
 package grpc_prometheus
 
 import (
-	"context"
-	"sync"
-
 	prom "github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc"
 )
 
-var (
-	// defaultServerMetrics is the default instance of ServerMetrics. It is
-	// intended to be used in conjunction the default Prometheus metrics
-	// registry.
-	defaultServerMetrics     *ServerMetrics
-	defaultServerMetricsOnce sync.Once
-)
-
-func DefaultServerMetrics() *ServerMetrics {
-	defaultServerMetricsOnce.Do(func() {
-		defaultServerMetrics = NewServerMetrics()
-
-		PrometheusMustRegister(defaultServerMetrics)
-	})
-
-	return defaultServerMetrics
-}
-
-// UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
-func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	return DefaultServerMetrics().UnaryServerInterceptor(ctx, req, info, handler)
-}
-
-// StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-func StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	return DefaultServerMetrics().StreamServerInterceptor(srv, ss, info, handler)
-}
-
+// PrometheusMustRegister when many servers with different const label
 func PrometheusMustRegister(serverMetrics *ServerMetrics) {
 	prom.MustRegister(serverMetrics.serverStartedCounter)
 	prom.MustRegister(serverMetrics.serverHandledCounter)
@@ -48,23 +17,11 @@ func PrometheusMustRegister(serverMetrics *ServerMetrics) {
 	prom.MustRegister(serverMetrics.serverStreamMsgSentCounter)
 }
 
-// Register takes a gRPC server and pre-initializes all counters to 0. This
-// allows for easier monitoring in Prometheus (no missing metrics), and should
-// be called *after* all services have been registered with the server. This
-// function acts on the DefaultServerMetrics variable.
-func Register(server *grpc.Server) {
-	DefaultServerMetrics().InitializeMetrics(server)
-}
-
-// DefaultEnableHandlingTimeHistogram turns on recording of handling time
+// EnableHandlingTimeHistogram turns on recording of handling time
 // of RPCs. Histogram metrics can be very expensive for Prometheus
 // to retain and query. This function acts on the DefaultServerMetrics
 // variable and the default Prometheus metrics registry.
-func EnableHandlingTimeHistogram(opts ...HistogramOption) {
-	CustomEnableHandlingTimeHistogram(DefaultServerMetrics(), opts...)
-}
-
-func CustomEnableHandlingTimeHistogram(serverMetrics *ServerMetrics, opts ...HistogramOption) {
+func EnableHandlingTimeHistogram(serverMetrics *ServerMetrics, opts ...HistogramOption) {
 	serverMetrics.EnableHandlingTimeHistogram(opts...)
 	prom.Register(serverMetrics.serverHandledHistogram)
 }

--- a/server.go
+++ b/server.go
@@ -9,19 +9,10 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-// PrometheusMustRegister when many servers with different const label
-func PrometheusMustRegister(serverMetrics *ServerMetrics) {
-	prom.MustRegister(serverMetrics.serverStartedCounter)
-	prom.MustRegister(serverMetrics.serverHandledCounter)
-	prom.MustRegister(serverMetrics.serverStreamMsgReceivedCounter)
-	prom.MustRegister(serverMetrics.serverStreamMsgSentCounter)
-}
-
-// EnableHandlingTimeHistogram turns on recording of handling time
-// of RPCs. Histogram metrics can be very expensive for Prometheus
-// to retain and query. This function acts on the DefaultServerMetrics
-// variable and the default Prometheus metrics registry.
-func EnableHandlingTimeHistogram(serverMetrics *ServerMetrics, opts ...HistogramOption) {
-	serverMetrics.EnableHandlingTimeHistogram(opts...)
-	prom.Register(serverMetrics.serverHandledHistogram)
+// MustRegister when many servers with different const label
+func (m *ServerMetrics) MustRegister() {
+	prom.MustRegister(m.serverStartedCounter)
+	prom.MustRegister(m.serverHandledCounter)
+	prom.MustRegister(m.serverStreamMsgReceivedCounter)
+	prom.MustRegister(m.serverStreamMsgSentCounter)
 }

--- a/server_extension.go
+++ b/server_extension.go
@@ -1,0 +1,29 @@
+package grpc_prometheus
+
+import "context"
+
+type Extension interface {
+	ServerSentMessageCustomLabels() []string
+	ServerSentMessageValues(ctx context.Context) []string
+	ServerReceivedMessageCustomLabels() []string
+	ServerReceivedMessageValues(ctx context.Context) []string
+}
+
+type defaultExtension struct {
+}
+
+func (d *defaultExtension) ServerSentMessageCustomLabels() []string {
+	return nil
+}
+
+func (d *defaultExtension) ServerSentMessageValues(ctx context.Context) []string {
+	return nil
+}
+
+func (d *defaultExtension) ServerReceivedMessageCustomLabels() []string {
+	return nil
+}
+
+func (d *defaultExtension) ServerReceivedMessageValues(ctx context.Context) []string {
+	return nil
+}

--- a/server_extension.go
+++ b/server_extension.go
@@ -4,87 +4,62 @@ import "context"
 
 type ServerExtension interface {
 	ServerStartedCounterCustomLabels() []string
-	ServerStartedCounterPreRegisterValues() [][]string
 	ServerStartedCounterValues(ctx context.Context) []string
 
 	ServerHandledCounterCustomLabels() []string
-	ServerHandledCounterPreRegisterValues() [][]string
 	ServerHandledCounterValues(ctx context.Context) []string
 
 	ServerStreamMsgReceivedCounterCustomLabels() []string
-	ServerStreamMsgReceivedCounterPreRegisterValues() [][]string
 	ServerStreamMsgReceivedCounterValues(ctx context.Context) []string
 
 	ServerStreamMsgSentCounterCustomLabels() []string
-	ServerStreamMsgSentCounterPreRegisterValues() [][]string
 	ServerStreamMsgSentCounterValues(ctx context.Context) []string
 
 	ServerHandledHistogramCustomLabels() []string
-	ServerHandledHistogramPreRegisterValues() [][]string
 	ServerHandledHistogramValues(ctx context.Context) []string
 }
 
-type NullExtension struct {
+type DefaultExtension struct {
 }
 
-var _ ServerExtension = NullExtension{}
+var _ ServerExtension = DefaultExtension{}
 
-func (NullExtension) ServerStartedCounterCustomLabels() []string {
+func (DefaultExtension) ServerStartedCounterCustomLabels() []string {
 	return nil
 }
 
-func (NullExtension) ServerStartedCounterPreRegisterValues() [][]string {
+func (DefaultExtension) ServerStartedCounterValues(context.Context) []string {
 	return nil
 }
 
-func (NullExtension) ServerStartedCounterValues(context.Context) []string {
+func (DefaultExtension) ServerHandledCounterCustomLabels() []string {
 	return nil
 }
 
-func (NullExtension) ServerHandledCounterCustomLabels() []string {
+func (DefaultExtension) ServerHandledCounterValues(context.Context) []string {
 	return nil
 }
 
-func (NullExtension) ServerHandledCounterPreRegisterValues() [][]string {
+func (DefaultExtension) ServerStreamMsgReceivedCounterCustomLabels() []string {
 	return nil
 }
 
-func (NullExtension) ServerHandledCounterValues(context.Context) []string {
+func (DefaultExtension) ServerStreamMsgReceivedCounterValues(context.Context) []string {
 	return nil
 }
 
-func (NullExtension) ServerStreamMsgReceivedCounterCustomLabels() []string {
+func (DefaultExtension) ServerStreamMsgSentCounterCustomLabels() []string {
 	return nil
 }
 
-func (NullExtension) ServerStreamMsgReceivedCounterPreRegisterValues() [][]string {
+func (DefaultExtension) ServerStreamMsgSentCounterValues(context.Context) []string {
 	return nil
 }
 
-func (NullExtension) ServerStreamMsgReceivedCounterValues(context.Context) []string {
+func (DefaultExtension) ServerHandledHistogramCustomLabels() []string {
 	return nil
 }
 
-func (NullExtension) ServerStreamMsgSentCounterCustomLabels() []string {
-	return nil
-}
-
-func (NullExtension) ServerStreamMsgSentCounterPreRegisterValues() [][]string {
-	return nil
-}
-
-func (NullExtension) ServerStreamMsgSentCounterValues(context.Context) []string {
-	return nil
-}
-
-func (NullExtension) ServerHandledHistogramCustomLabels() []string {
-	return nil
-}
-
-func (NullExtension) ServerHandledHistogramPreRegisterValues() [][]string {
-	return nil
-}
-
-func (NullExtension) ServerHandledHistogramValues(context.Context) []string {
+func (DefaultExtension) ServerHandledHistogramValues(context.Context) []string {
 	return nil
 }

--- a/server_extension.go
+++ b/server_extension.go
@@ -2,28 +2,89 @@ package grpc_prometheus
 
 import "context"
 
-type Extension interface {
-	ServerSentMessageCustomLabels() []string
-	ServerSentMessageValues(ctx context.Context) []string
-	ServerReceivedMessageCustomLabels() []string
-	ServerReceivedMessageValues(ctx context.Context) []string
+type ServerExtension interface {
+	ServerStartedCounterCustomLabels() []string
+	ServerStartedCounterPreRegisterValues() [][]string
+	ServerStartedCounterValues(ctx context.Context) []string
+
+	ServerHandledCounterCustomLabels() []string
+	ServerHandledCounterPreRegisterValues() [][]string
+	ServerHandledCounterValues(ctx context.Context) []string
+
+	ServerStreamMsgReceivedCounterCustomLabels() []string
+	ServerStreamMsgReceivedCounterPreRegisterValues() [][]string
+	ServerStreamMsgReceivedCounterValues(ctx context.Context) []string
+
+	ServerStreamMsgSentCounterCustomLabels() []string
+	ServerStreamMsgSentCounterPreRegisterValues() [][]string
+	ServerStreamMsgSentCounterValues(ctx context.Context) []string
+
+	ServerHandledHistogramCustomLabels() []string
+	ServerHandledHistogramPreRegisterValues() [][]string
+	ServerHandledHistogramValues(ctx context.Context) []string
 }
 
-type defaultExtension struct {
+type NullExtension struct {
 }
 
-func (d *defaultExtension) ServerSentMessageCustomLabels() []string {
+var _ ServerExtension = NullExtension{}
+
+func (NullExtension) ServerStartedCounterCustomLabels() []string {
 	return nil
 }
 
-func (d *defaultExtension) ServerSentMessageValues(ctx context.Context) []string {
+func (NullExtension) ServerStartedCounterPreRegisterValues() [][]string {
 	return nil
 }
 
-func (d *defaultExtension) ServerReceivedMessageCustomLabels() []string {
+func (NullExtension) ServerStartedCounterValues(context.Context) []string {
 	return nil
 }
 
-func (d *defaultExtension) ServerReceivedMessageValues(ctx context.Context) []string {
+func (NullExtension) ServerHandledCounterCustomLabels() []string {
+	return nil
+}
+
+func (NullExtension) ServerHandledCounterPreRegisterValues() [][]string {
+	return nil
+}
+
+func (NullExtension) ServerHandledCounterValues(context.Context) []string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgReceivedCounterCustomLabels() []string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgReceivedCounterPreRegisterValues() [][]string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgReceivedCounterValues(context.Context) []string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgSentCounterCustomLabels() []string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgSentCounterPreRegisterValues() [][]string {
+	return nil
+}
+
+func (NullExtension) ServerStreamMsgSentCounterValues(context.Context) []string {
+	return nil
+}
+
+func (NullExtension) ServerHandledHistogramCustomLabels() []string {
+	return nil
+}
+
+func (NullExtension) ServerHandledHistogramPreRegisterValues() [][]string {
+	return nil
+}
+
+func (NullExtension) ServerHandledHistogramValues(context.Context) []string {
 	return nil
 }

--- a/server_extension.go
+++ b/server_extension.go
@@ -3,9 +3,6 @@ package grpc_prometheus
 import "context"
 
 type ServerExtension interface {
-	ServerStartedCounterCustomLabels() []string
-	ServerStartedCounterValues(ctx context.Context) []string
-
 	ServerHandledCounterCustomLabels() []string
 	ServerHandledCounterValues(ctx context.Context) []string
 
@@ -22,15 +19,7 @@ type ServerExtension interface {
 type DefaultExtension struct {
 }
 
-var _ ServerExtension = DefaultExtension{}
-
-func (DefaultExtension) ServerStartedCounterCustomLabels() []string {
-	return nil
-}
-
-func (DefaultExtension) ServerStartedCounterValues(context.Context) []string {
-	return nil
-}
+var emptyExtension ServerExtension = DefaultExtension{}
 
 func (DefaultExtension) ServerHandledCounterCustomLabels() []string {
 	return nil

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -9,15 +9,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-type UnaryServerInterceptorType = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error)
-
-type StreamServerInterceptorType = func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error
-
 var (
 	lock                    sync.RWMutex
 	defaultServerMetrics    *ServerMetrics
-	unaryServerInterceptor  UnaryServerInterceptorType
-	streamServerInterceptor StreamServerInterceptorType
+	unaryServerInterceptor  grpc.UnaryServerInterceptor
+	streamServerInterceptor grpc.StreamServerInterceptor
 )
 
 // DefaultServerMetrics is the default instance of ServerMetrics. It is
@@ -31,7 +27,7 @@ func DefaultServerMetrics() *ServerMetrics {
 }
 
 // StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-func StreamServerInterceptor() StreamServerInterceptorType {
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
 	if streamServerInterceptor == nil {
 		Configure()
 	}
@@ -39,7 +35,7 @@ func StreamServerInterceptor() StreamServerInterceptorType {
 	return streamServerInterceptor
 }
 
-func UnaryServerInterceptor() UnaryServerInterceptorType {
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	if unaryServerInterceptor == nil {
 		Configure()
 	}

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -68,17 +68,13 @@ func NewServerMetricsWithExtension(extension ServerExtension, counterOpts ...Cou
 // expensive on Prometheus servers. It takes options to configure histogram
 // options such as the defined buckets.
 func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramOption) {
-	m.EnableHandlingTimeHistogramWithExtension(&NullExtension{}, opts...)
-}
-
-func (m *ServerMetrics) EnableHandlingTimeHistogramWithExtension(extension ServerExtension, opts ...HistogramOption) {
 	for _, o := range opts {
 		o(&m.serverHandledHistogramOpts)
 	}
 	if !m.serverHandledHistogramEnabled {
 		m.serverHandledHistogram = prom.NewHistogramVec(
 			m.serverHandledHistogramOpts,
-			append(extension.ServerHandledHistogramCustomLabels(), "grpc_type", "grpc_service", "grpc_method"),
+			append(m.extension.ServerHandledHistogramCustomLabels(), "grpc_type", "grpc_service", "grpc_method"),
 		)
 	}
 	m.serverHandledHistogramEnabled = true

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -137,14 +137,10 @@ func (m *ServerMetrics) StreamServerInterceptor() func(srv interface{}, ss grpc.
 // value, for all gRPC methods registered on a gRPC server. This is useful, to
 // ensure that all metrics exist when collecting and querying.
 func (m *ServerMetrics) InitializeMetrics(server *grpc.Server) {
-	m.InitializeMetricsWithExtension(server, &NullExtension{})
-}
-
-func (m *ServerMetrics) InitializeMetricsWithExtension(server *grpc.Server, extension ServerExtension) {
 	serviceInfo := server.GetServiceInfo()
 	for serviceName, info := range serviceInfo {
 		for _, mInfo := range info.Methods {
-			preRegisterMethod(m, serviceName, &mInfo, extension)
+			preRegisterMethod(m, serviceName, &mInfo, m.extension)
 		}
 	}
 }

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -20,27 +20,19 @@ var (
 // intended to be used in conjunction the default Prometheus metrics
 // registry.
 func DefaultServerMetrics() *ServerMetrics {
-	if defaultServerMetrics == nil {
-		Configure()
-	}
+	Configure()
 	return defaultServerMetrics
 }
 
 // StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
-	if streamServerInterceptor == nil {
-		Configure()
-	}
-
+	Configure()
 	return streamServerInterceptor
 }
 
 // UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	if unaryServerInterceptor == nil {
-		Configure()
-	}
-
+	Configure()
 	return unaryServerInterceptor
 }
 

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -189,7 +189,7 @@ type monitoredServerStream struct {
 func (s *monitoredServerStream) SendMsg(m interface{}) error {
 	err := s.ServerStream.SendMsg(m)
 	if err == nil {
-		s.monitor.SentMessage(context.Background())
+		s.monitor.SentMessage(s.ServerStream.Context())
 	}
 	return err
 }
@@ -197,7 +197,7 @@ func (s *monitoredServerStream) SendMsg(m interface{}) error {
 func (s *monitoredServerStream) RecvMsg(m interface{}) error {
 	err := s.ServerStream.RecvMsg(m)
 	if err == nil {
-		s.monitor.ReceivedMessage(context.Background())
+		s.monitor.ReceivedMessage(s.ServerStream.Context())
 	}
 	return err
 }

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -17,7 +17,6 @@ type ServerMetrics struct {
 	serverStreamMsgReceivedCounter *prom.CounterVec
 	serverStreamMsgSentCounter     *prom.CounterVec
 	serverHandledHistogramEnabled  bool
-	serverHandledHistogramOpts     prom.HistogramOpts
 	serverHandledHistogram         *prom.HistogramVec
 }
 
@@ -54,12 +53,7 @@ func NewServerMetricsWithExtension(extension ServerExtension, counterOpts ...Cou
 				Help: "Total number of gRPC stream messages sent by the server.",
 			}), append(extension.ServerStreamMsgSentCounterCustomLabels(), "grpc_type", "grpc_service", "grpc_method")),
 		serverHandledHistogramEnabled: false,
-		serverHandledHistogramOpts: prom.HistogramOpts{
-			Name:    "grpc_server_handling_seconds",
-			Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
-			Buckets: prom.DefBuckets,
-		},
-		serverHandledHistogram: nil,
+		serverHandledHistogram:        nil,
 	}
 }
 
@@ -68,15 +62,22 @@ func NewServerMetricsWithExtension(extension ServerExtension, counterOpts ...Cou
 // expensive on Prometheus servers. It takes options to configure histogram
 // options such as the defined buckets.
 func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramOption) {
+	if m.serverHandledHistogramEnabled {
+		return
+	}
+
+	serverHandledHistogramOpts := prom.HistogramOpts{
+		Name:    "grpc_server_handling_seconds",
+		Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+		Buckets: prom.DefBuckets,
+	}
 	for _, o := range opts {
-		o(&m.serverHandledHistogramOpts)
+		o(&serverHandledHistogramOpts)
 	}
-	if !m.serverHandledHistogramEnabled {
-		m.serverHandledHistogram = prom.NewHistogramVec(
-			m.serverHandledHistogramOpts,
-			append(m.extension.ServerHandledHistogramCustomLabels(), "grpc_type", "grpc_service", "grpc_method"),
-		)
-	}
+	m.serverHandledHistogram = prom.NewHistogramVec(
+		serverHandledHistogramOpts,
+		append(m.extension.ServerHandledHistogramCustomLabels(), "grpc_type", "grpc_service", "grpc_method"),
+	)
 	m.serverHandledHistogramEnabled = true
 }
 

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -35,6 +35,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return streamServerInterceptor
 }
 
+// UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	if unaryServerInterceptor == nil {
 		Configure()
@@ -42,8 +43,6 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 	return unaryServerInterceptor
 }
-
-// UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
 
 func Configure() {
 	ConfigureWithExtension(emptyExtension)

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -108,7 +108,7 @@ func (m *ServerMetrics) Collect(ch chan<- prom.Metric) {
 
 // UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
 func (m *ServerMetrics) UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	monitor := newServerReporter(m, ctx, Unary, info.FullMethod)
+	monitor := newServerReporter(ctx, m, Unary, info.FullMethod)
 	monitor.ReceivedMessage(ctx)
 	resp, err := handler(ctx, req)
 	st, _ := grpcstatus.FromError(err)
@@ -121,7 +121,7 @@ func (m *ServerMetrics) UnaryServerInterceptor(ctx context.Context, req interfac
 
 // StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
 func (m *ServerMetrics) StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	monitor := newServerReporter(m, ss.Context(), streamRPCType(info), info.FullMethod)
+	monitor := newServerReporter(ss.Context(), m, streamRPCType(info), info.FullMethod)
 	err := handler(srv, &monitoredServerStream{ss, monitor})
 	st, _ := grpcstatus.FromError(err)
 	monitor.Handled(ss.Context(), st.Code())

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -68,16 +68,20 @@ func NewServerMetricsWithExtension(extension ServerExtension, counterOpts ...Cou
 // expensive on Prometheus servers. It takes options to configure histogram
 // options such as the defined buckets.
 func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramOption) {
+	if m.serverHandledHistogramEnabled {
+		return // already enabled
+	}
+
 	for _, o := range opts {
 		o(&m.serverHandledHistogramOpts)
 	}
-	if !m.serverHandledHistogramEnabled {
-		m.serverHandledHistogram = prom.NewHistogramVec(
-			m.serverHandledHistogramOpts,
-			[]string{"grpc_type", "grpc_service", "grpc_method"},
-		)
-	}
+	m.serverHandledHistogram = prom.NewHistogramVec(
+		m.serverHandledHistogramOpts,
+		[]string{"grpc_type", "grpc_service", "grpc_method"},
+	)
 	m.serverHandledHistogramEnabled = true
+
+	prom.MustRegister(m.serverHandledHistogram)
 }
 
 // Describe sends the super-set of all possible descriptors of metrics

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -51,6 +51,9 @@ func Configure() {
 func ConfigureWithExtension(extension ServerExtension) {
 	lock.Lock()
 	defer lock.Unlock()
+	if defaultServerMetrics != nil {
+		return
+	}
 
 	// DefaultServerMetrics is the default instance of ServerMetrics. It is
 	// intended to be used in conjunction the default Prometheus metrics

--- a/server_reporter.go
+++ b/server_reporter.go
@@ -18,7 +18,7 @@ type serverReporter struct {
 	startTime   time.Time
 }
 
-func newServerReporter(m *ServerMetrics, ctx context.Context, rpcType grpcType, fullMethod string) *serverReporter {
+func newServerReporter(ctx context.Context, m *ServerMetrics, rpcType grpcType, fullMethod string) *serverReporter {
 	r := &serverReporter{
 		metrics: m,
 		rpcType: rpcType,

--- a/server_reporter.go
+++ b/server_reporter.go
@@ -18,7 +18,7 @@ type serverReporter struct {
 	startTime   time.Time
 }
 
-func newServerReporter(ctx context.Context, m *ServerMetrics, rpcType grpcType, fullMethod string) *serverReporter {
+func newServerReporter(m *ServerMetrics, rpcType grpcType, fullMethod string) *serverReporter {
 	r := &serverReporter{
 		metrics: m,
 		rpcType: rpcType,
@@ -27,10 +27,7 @@ func newServerReporter(ctx context.Context, m *ServerMetrics, rpcType grpcType, 
 		r.startTime = time.Now()
 	}
 	r.serviceName, r.methodName = splitMethodName(fullMethod)
-	r.metrics.serverStartedCounter.WithLabelValues(append(
-		r.metrics.extension.ServerStartedCounterValues(ctx),
-		string(r.rpcType), r.serviceName, r.methodName)...,
-	).Inc()
+	r.metrics.serverStartedCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
 	return r
 }
 

--- a/server_reporter.go
+++ b/server_reporter.go
@@ -4,6 +4,7 @@
 package grpc_prometheus
 
 import (
+	"context"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -30,12 +31,16 @@ func newServerReporter(m *ServerMetrics, rpcType grpcType, fullMethod string) *s
 	return r
 }
 
-func (r *serverReporter) ReceivedMessage() {
-	r.metrics.serverStreamMsgReceived.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+func (r *serverReporter) ReceivedMessage(ctx context.Context) {
+	customLabelValues := r.metrics.extension.ServerReceivedMessageValues(ctx)
+	labels := append(customLabelValues, string(r.rpcType), r.serviceName, r.methodName)
+	r.metrics.serverStreamMsgReceived.WithLabelValues(labels...).Inc()
 }
 
-func (r *serverReporter) SentMessage() {
-	r.metrics.serverStreamMsgSent.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+func (r *serverReporter) SentMessage(ctx context.Context) {
+	customLabelValues := r.metrics.extension.ServerSentMessageValues(ctx)
+	labels := append(customLabelValues, string(r.rpcType), r.serviceName, r.methodName)
+	r.metrics.serverStreamMsgSent.WithLabelValues(labels...).Inc()
 }
 
 func (r *serverReporter) Handled(code codes.Code) {

--- a/server_test.go
+++ b/server_test.go
@@ -72,8 +72,8 @@ func (s *ServerInterceptorTestSuite) SetupSuite() {
 
 	// This is the point where we hook up the interceptor
 	s.server = grpc.NewServer(
-		grpc.StreamInterceptor(defaultServerMetrics.StreamServerInterceptor),
-		grpc.UnaryInterceptor(defaultServerMetrics.UnaryServerInterceptor),
+		grpc.StreamInterceptor(defaultServerMetrics.StreamServerInterceptor()),
+		grpc.UnaryInterceptor(defaultServerMetrics.UnaryServerInterceptor()),
 	)
 	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
 

--- a/server_test.go
+++ b/server_test.go
@@ -58,15 +58,15 @@ type ServerInterceptorTestSuite struct {
 func (s *ServerInterceptorTestSuite) SetupSuite() {
 	var err error
 
-	DefaultEnableHandlingTimeHistogram()
+	EnableHandlingTimeHistogram()
 
 	s.serverListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(s.T(), err, "must be able to allocate a port for serverListener")
 
 	// This is the point where we hook up the interceptor
 	s.server = grpc.NewServer(
-		grpc.StreamInterceptor(StreamServerInterceptor()),
-		grpc.UnaryInterceptor(UnaryServerInterceptor()),
+		grpc.StreamInterceptor(StreamServerInterceptor),
+		grpc.UnaryInterceptor(UnaryServerInterceptor),
 	)
 	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
 

--- a/server_test.go
+++ b/server_test.go
@@ -22,7 +22,6 @@ import (
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-prometheus/examples/testproto"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -39,6 +38,14 @@ const (
 	pingDefaultValue   = "I like kittens."
 	countListResponses = 20
 )
+
+var (
+	defaultServerMetrics = NewServerMetrics()
+)
+
+func init() {
+	PrometheusMustRegister(defaultServerMetrics)
+}
 
 func TestServerInterceptorSuite(t *testing.T) {
 	suite.Run(t, &ServerInterceptorTestSuite{})
@@ -58,15 +65,15 @@ type ServerInterceptorTestSuite struct {
 func (s *ServerInterceptorTestSuite) SetupSuite() {
 	var err error
 
-	EnableHandlingTimeHistogram()
+	EnableHandlingTimeHistogram(defaultServerMetrics)
 
 	s.serverListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(s.T(), err, "must be able to allocate a port for serverListener")
 
 	// This is the point where we hook up the interceptor
 	s.server = grpc.NewServer(
-		grpc.StreamInterceptor(StreamServerInterceptor),
-		grpc.UnaryInterceptor(UnaryServerInterceptor),
+		grpc.StreamInterceptor(defaultServerMetrics.StreamServerInterceptor),
+		grpc.UnaryInterceptor(defaultServerMetrics.UnaryServerInterceptor),
 	)
 	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
 
@@ -84,12 +91,11 @@ func (s *ServerInterceptorTestSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.TODO(), 2*time.Second)
 
 	// Make sure every test starts with same fresh, intialized metric state.
-	DefaultServerMetrics().serverStartedCounter.Reset()
-	DefaultServerMetrics().serverHandledCounter.Reset()
-	DefaultServerMetrics().serverHandledHistogram.Reset()
-	DefaultServerMetrics().serverStreamMsgReceivedCounter.Reset()
-	DefaultServerMetrics().serverStreamMsgSentCounter.Reset()
-	Register(s.server)
+	defaultServerMetrics.serverStartedCounter.Reset()
+	defaultServerMetrics.serverHandledCounter.Reset()
+	defaultServerMetrics.serverHandledHistogram.Reset()
+	defaultServerMetrics.serverStreamMsgReceivedCounter.Reset()
+	defaultServerMetrics.serverStreamMsgSentCounter.Reset()
 }
 
 func (s *ServerInterceptorTestSuite) TearDownSuite() {
@@ -108,52 +114,30 @@ func (s *ServerInterceptorTestSuite) TearDownTest() {
 	s.cancel()
 }
 
-func (s *ServerInterceptorTestSuite) TestRegisterPresetsStuff() {
-	for testID, testCase := range []struct {
-		metricName     string
-		existingLabels []string
-	}{
-		// Order of label is irrelevant.
-		{"grpc_server_started_total", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary"}},
-		{"grpc_server_started_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream"}},
-		{"grpc_server_msg_received_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream"}},
-		{"grpc_server_msg_sent_total", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary"}},
-		{"grpc_server_handling_seconds_sum", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary"}},
-		{"grpc_server_handling_seconds_count", []string{"mwitkow.testproto.TestService", "PingList", "server_stream"}},
-		{"grpc_server_handled_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream", "OutOfRange"}},
-		{"grpc_server_handled_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream", "Aborted"}},
-		{"grpc_server_handled_total", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary", "FailedPrecondition"}},
-		{"grpc_server_handled_total", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary", "ResourceExhausted"}},
-	} {
-		lineCount := len(fetchPrometheusLines(s.T(), testCase.metricName, testCase.existingLabels...))
-		assert.NotEqual(s.T(), 0, lineCount, "metrics must exist for test case %d", testID)
-	}
-}
-
 func (s *ServerInterceptorTestSuite) TestUnaryIncrementsMetrics() {
 	_, err := s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
 	require.NoError(s.T(), err)
-	requireValue(s.T(), 1, DefaultServerMetrics().serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
-	requireValue(s.T(), 1, DefaultServerMetrics().serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty", "OK"))
-	requireValueHistCount(s.T(), 1, DefaultServerMetrics().serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, defaultServerMetrics.serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, defaultServerMetrics.serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty", "OK"))
+	requireValueHistCount(s.T(), 1, defaultServerMetrics.serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
 
 	_, err = s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.Error(s.T(), err)
-	requireValue(s.T(), 1, DefaultServerMetrics().serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
-	requireValue(s.T(), 1, DefaultServerMetrics().serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError", "FailedPrecondition"))
-	requireValueHistCount(s.T(), 1, DefaultServerMetrics().serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
+	requireValue(s.T(), 1, defaultServerMetrics.serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
+	requireValue(s.T(), 1, defaultServerMetrics.serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 1, defaultServerMetrics.serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
 }
 
 func (s *ServerInterceptorTestSuite) TestStartedStreamingIncrementsStarted() {
 	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
 	require.NoError(s.T(), err)
 	requireValueWithRetry(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 
 	_, err = s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
 	requireValueWithRetry(s.ctx, s.T(), 2,
-		DefaultServerMetrics().serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }
 
 func (s *ServerInterceptorTestSuite) TestStreamingIncrementsMetrics() {
@@ -171,25 +155,25 @@ func (s *ServerInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	require.EqualValues(s.T(), countListResponses, count, "Number of received msg on the wire must match")
 
 	requireValueWithRetry(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 	requireValueWithRetry(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "OK"))
+		defaultServerMetrics.serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "OK"))
 	requireValueWithRetry(s.ctx, s.T(), countListResponses,
-		DefaultServerMetrics().serverStreamMsgSentCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStreamMsgSentCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 	requireValueWithRetry(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverStreamMsgReceivedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStreamMsgReceivedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 	requireValueWithRetryHistCount(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 
 	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
 
 	requireValueWithRetry(s.ctx, s.T(), 2,
-		DefaultServerMetrics().serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 	requireValueWithRetry(s.ctx, s.T(), 1,
-		DefaultServerMetrics().serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "FailedPrecondition"))
+		defaultServerMetrics.serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "FailedPrecondition"))
 	requireValueWithRetryHistCount(s.ctx, s.T(), 2,
-		DefaultServerMetrics().serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+		defaultServerMetrics.serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }
 
 // fetchPrometheusLines does mocked HTTP GET request against real prometheus handler to get the same view that Prometheus

--- a/server_test.go
+++ b/server_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	PrometheusMustRegister(defaultServerMetrics)
+	defaultServerMetrics.MustRegister()
 }
 
 func TestServerInterceptorSuite(t *testing.T) {
@@ -65,7 +65,7 @@ type ServerInterceptorTestSuite struct {
 func (s *ServerInterceptorTestSuite) SetupSuite() {
 	var err error
 
-	EnableHandlingTimeHistogram(defaultServerMetrics)
+	defaultServerMetrics.EnableHandlingTimeHistogram()
 
 	s.serverListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(s.T(), err, "must be able to allocate a port for serverListener")

--- a/server_test.go
+++ b/server_test.go
@@ -39,10 +39,6 @@ const (
 	countListResponses = 20
 )
 
-func init() {
-	Configure()
-}
-
 func TestServerInterceptorSuite(t *testing.T) {
 	suite.Run(t, &ServerInterceptorTestSuite{})
 }
@@ -60,6 +56,8 @@ type ServerInterceptorTestSuite struct {
 
 func (s *ServerInterceptorTestSuite) SetupSuite() {
 	var err error
+
+	Configure()
 
 	defaultServerMetrics.EnableHandlingTimeHistogram()
 

--- a/server_test.go
+++ b/server_test.go
@@ -39,12 +39,8 @@ const (
 	countListResponses = 20
 )
 
-var (
-	defaultServerMetrics = NewServerMetrics()
-)
-
 func init() {
-	defaultServerMetrics.MustRegister()
+	Configure()
 }
 
 func TestServerInterceptorSuite(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 )
 
 type grpcType string
@@ -17,15 +16,6 @@ const (
 	ClientStream grpcType = "client_stream"
 	ServerStream grpcType = "server_stream"
 	BidiStream   grpcType = "bidi_stream"
-)
-
-var (
-	allCodes = []codes.Code{
-		codes.OK, codes.Canceled, codes.Unknown, codes.InvalidArgument, codes.DeadlineExceeded, codes.NotFound,
-		codes.AlreadyExists, codes.PermissionDenied, codes.Unauthenticated, codes.ResourceExhausted,
-		codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.Unimplemented, codes.Internal,
-		codes.Unavailable, codes.DataLoss,
-	}
 )
 
 func splitMethodName(fullMethodName string) (string, string) {

--- a/util.go
+++ b/util.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 type grpcType string
@@ -16,6 +17,15 @@ const (
 	ClientStream grpcType = "client_stream"
 	ServerStream grpcType = "server_stream"
 	BidiStream   grpcType = "bidi_stream"
+)
+
+var (
+	allCodes = []codes.Code{
+		codes.OK, codes.Canceled, codes.Unknown, codes.InvalidArgument, codes.DeadlineExceeded, codes.NotFound,
+		codes.AlreadyExists, codes.PermissionDenied, codes.Unauthenticated, codes.ResourceExhausted,
+		codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.Unimplemented, codes.Internal,
+		codes.Unavailable, codes.DataLoss,
+	}
 )
 
 func splitMethodName(fullMethodName string) (string, string) {


### PR DESCRIPTION
[PMM-10948](https://jira.percona.com/browse/PMM-10948)

**Changes:**
 - Do not publish empty metrics.
 - Possibility to specify custom labels for gRPC server metrics.